### PR TITLE
refactor(setup): make setup one-step

### DIFF
--- a/src/functions/config/setConfirmMessage.ts
+++ b/src/functions/config/setConfirmMessage.ts
@@ -14,10 +14,10 @@ import {
 import colours from "../../constants/colours.js";
 import { formatConfirmMessage } from "../formatConfirmMessage.js";
 
-const DEFAULT_MESSAGE_REPORT_MSG = `Are you sure you want to report [this message]({{message}}) to the server moderators?\n**Reason**: {{field1}}`;
-const DEFAULT_USER_REPORT_MSG = `Are you sure you want to report {{user}} to the server moderators?\n**Reason**: {{field1}}`;
+export const DEFAULT_MESSAGE_REPORT_MSG = `Are you sure you want to report [this message]({{message}}) to the server moderators?\n**Reason**: {{field1}}`;
+export const DEFAULT_USER_REPORT_MSG = `Are you sure you want to report {{user}} to the server moderators?\n**Reason**: {{field1}}`;
 
-const EXMAPLE_FIELDS = [
+const EXAMPLE_FIELDS = [
   "Example response",
   "Example response",
   "Example response",
@@ -33,8 +33,8 @@ export async function setConfirmMessage(
 ): Promise<{ messageReportMsg: string; userReportMsg: string }> {
   function setEmbedFields(embed: EmbedBuilder) {
     return embed.setFields(
-      { name: "Message reports", value: formatConfirmMessage(1024, EXMAPLE_FIELDS, messageReportMsg, userId, message) },
-      { name: "User reports", value: formatConfirmMessage(1024, EXMAPLE_FIELDS, userReportMsg, userId) },
+      { name: "Message reports", value: formatConfirmMessage(1024, EXAMPLE_FIELDS, messageReportMsg, userId, message) },
+      { name: "User reports", value: formatConfirmMessage(1024, EXAMPLE_FIELDS, userReportMsg, userId) },
     );
   }
 
@@ -46,7 +46,7 @@ export async function setConfirmMessage(
     })
     .setTitle("Configure your confirmation messages")
     .setDescription(
-      "After your members complete the questions you entered before, Reindeer will send a confirmation message before actually submitting the report. Below is a preivew of your confirmation messages.",
+      "After your members complete the questions you entered before, Reindeer will send a confirmation message before actually submitting the report. Below is a preview of your confirmation messages.",
     );
 
   const tipEmbed = new EmbedBuilder()

--- a/src/functions/config/setFields.ts
+++ b/src/functions/config/setFields.ts
@@ -22,7 +22,9 @@ export type Field = {
   max: number;
 };
 
-const DEFAULT_FIELDS: Field[] = [{ name: "Reason for the report", placeholder: null, style: 2, min: 1, max: 1024 }];
+export const DEFAULT_FIELDS: Field[] = [
+  { name: "Reason for the report", placeholder: null, style: 2, min: 1, max: 1024 },
+];
 
 function formatFields(fields: Field[]) {
   return fields.map((field, index) => ({


### PR DESCRIPTION
https://bluesharkriver.notion.site/Make-setup-one-step-f83a30f1e6f747ad8f79347927e543ef?pvs=4

Below is a copy of the Notion task.

---

## Most people don’t care about the advanced options (like custom messages, permissions, cooldowns)

- This is also when most people kick the bot, presumably because they don’t know what to do
- We should make `/setup` a one-step command and only include the first channel setup step
- After setup, the user can utilise one of the `/config` commands or the future dashboard to configure advanced options (including future features, like Global Alert)